### PR TITLE
Support showNotes configuration

### DIFF
--- a/templates/document.html.slim
+++ b/templates/document.html.slim
@@ -109,6 +109,8 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         controls: #{to_boolean(attr 'revealjs_controls', true)},
         // Display a presentation progress bar
         progress: #{to_boolean(attr 'revealjs_progress', true)},
+        // Set default timing of 2 minutes per slide
+      	defaultTiming: #{attr 'revealjs_defaultTiming', 3},
         // Display the page number of the current slide
         slideNumber: #{to_boolean(attr 'revealjs_slidenumber', false)},
         // Push each slide change to the browser history
@@ -125,11 +127,23 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         loop: #{to_boolean(attr 'revealjs_loop', false)},
         // Change the presentation direction to be RTL
         rtl: #{to_boolean(attr 'revealjs_rtl', false)},
+        // Randomizes the order of slides each time the presentation loads
+	      shuffle: #{to_boolean(attr 'revealjs_shuffle', false)},
         // Turns fragments on and off globally
         fragments: #{to_boolean(attr 'revealjs_fragments', true)},
         // Flags if the presentation is running in an embedded mode,
         // i.e. contained within a limited portion of the screen
         embedded: #{to_boolean(attr 'revealjs_embedded', false)},
+        // Flags if we should show a help overlay when the questionmark
+      	// key is pressed
+      	help: true,
+        // Flags if speaker notes should be visible to all viewers
+        showNotes: #{to_boolean(attr 'revealjs_showNotes', false)},
+        // Global override for autolaying embedded media (video/audio/iframe)
+      	// - null: Media will only autoplay if data-autoplay is present
+      	// - true: All media will autoplay, regardless of individual setting
+      	// - false: No media will autoplay, regardless of individual setting
+      	autoPlayMedia: #{to_boolean(attr 'revealjs_autoPlayMedia', null)},
         // Number of milliseconds between automatically proceeding to the
         // next slide, disabled when set to 0, this value can be overwritten
         // by using a data-autoslide attribute on your slides
@@ -157,7 +171,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         parallaxBackgroundImage: '#{attr 'revealjs_parallaxbackgroundimage', ''}',
         // Parallax background size in CSS syntax (e.g., "2100px 900px")
         parallaxBackgroundSize: '#{attr 'revealjs_parallaxbackgroundsize', ''}',
-        
+
         // The "normal" size of the presentation, aspect ratio will be preserved
         // when the presentation is scaled to fit different resolutions. Can be
         // specified using percentage units.
@@ -170,7 +184,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
         // Bounds for smallest/largest possible scale to apply to content
         minScale: #{attr 'revealjs_minscale', 0.2},
         maxScale: #{attr 'revealjs_maxscale', 1.5},
-        
+
         // Optional libraries used to extend on reveal.js
         dependencies: [
             { src: '#{revealjsdir}/lib/js/classList.js', condition: function() { return !document.body.classList; } },


### PR DESCRIPTION
This is a feature documented in reveal.js's README, but not supported yet.